### PR TITLE
chore(ci): Replace archived actions-rs actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Set up Rust
         run: |
-           rustup toolchain add --profile=minimal nightly
+           rustup toolchain add --profile=minimal --component rustfmt,clippy nightly
            rustup override set nightly
       - name: Update version in Cargo.toml
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,11 +29,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-            toolchain: nightly
-            override: true
-            components: rustfmt, clippy
+        run: |
+           rustup toolchain add --profile=minimal nightly
+           rustup override set nightly
       - name: Update version in Cargo.toml
         run: |
           VERSION=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -154,7 +154,7 @@ jobs:
 #            os: ubuntu-latest
 
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-13
           - target: aarch64-apple-darwin
             os: macos-14
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,8 +29,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - run: |
-           rustup toolchain add ${{ matrix.target == 'i686-pc-windows-gnu' && format('{0}-i686-pc-windows-gnu', matrix.channel) || matrix.channel }}
+      - name: Setup toolchain
+        env:
+          TOOLCHAIN: ${{ matrix.target == 'i686-pc-windows-gnu' && format('{0}-i686-pc-windows-gnu', matrix.channel) || matrix.channel }}
+        run: |
+           rustup toolchain add --component rustfmt --target ${{ matrix.target }} $TOOLCHAIN
 
       - run: |
           cargo fmt --all -- --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,17 +29,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.target == 'i686-pc-windows-gnu' && format('{0}-i686-pc-windows-gnu', matrix.channel) || matrix.channel }}
-          target: ${{ matrix.target }}
-          override: true
-          components: rustfmt
+      - run: |
+           rustup toolchain add ${{ matrix.target == 'i686-pc-windows-gnu' && format('{0}-i686-pc-windows-gnu', matrix.channel) || matrix.channel }}
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: |
+          cargo fmt --all -- --check
 
       - uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
The actions-rs org has been archived for years at this point and it doesn't look like it's coming back. For security reasons we are going to remove it from the list of allowed actions in the org soon. (See https://github.com/apache/infrastructure-actions)
